### PR TITLE
include -> use pins.scad

### DIFF
--- a/arduino.scad
+++ b/arduino.scad
@@ -20,7 +20,7 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-include <pins.scad>
+use <pins.scad>
 
 //Constructs a roughed out arduino board
 //Current only USB, power and headers


### PR DESCRIPTION
Changed "include" to "use" to prevent that the sample code in newer pins.scad versions gets executed and displayed in the Arduino examples.
