### PR TITLE
Library dependency for pin connectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@ The library has a variety of modules for creating Arduinos and Arduino mounts. H
 
 ![openscadarduinomounting](https://cloud.githubusercontent.com/assets/492003/9833469/f1cbe2dc-5965-11e5-8357-0297916c8885.jpg)
 
+## Dependencies
+
+Using the [library location instructions](https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Libraries),
+checkout the `pin_connectors` library in the `libraries` folder:
+
+    git clone https://github.com/tbuser/pin_connectors.git
+
+This makes the `pin_connectors/pins.scad` dependency available.
+
 ###arduino(boardType)
 **boardType** - UNO, LEONARDO, DUEMILANOVE, DIECIMILA, DUE, MEGA, MEGA 2560, ETHERNET
 

--- a/arduino.scad
+++ b/arduino.scad
@@ -20,7 +20,7 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-use <pins.scad>
+use <pin_connectors/pins.scad>
 
 //Constructs a roughed out arduino board
 //Current only USB, power and headers


### PR DESCRIPTION
OpenSCAD has a libraries folder which makes inter-library dependencies more straight forward.

Change to use a relative path to use <pin_connectors/pins.scad> which now relies on adding the library to the library path as per https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Libraries

Updated documentation with basic instructions.