### PR TITLE
Add optional vent holes to lid.

### DIFF
--- a/arduino.scad
+++ b/arduino.scad
@@ -182,6 +182,16 @@ module enclosureLid( boardType = UNO, wall = 3, offset = 3, cornerRadius = 3, ve
       }
 
     }
+    if (ventHoles) {
+       translate([(wall+offset+0.5),(wall+offset+0.5),-5]) {
+       	  cube([5,boardDim[0]-5,10]);
+       }
+       translate([pcbDim[0]-(wall+offset+6),(wall+offset+0.5),-5]) {
+       	  cube([5,boardDim[0]-5,10]);
+       }
+       
+      
+   }
   }
 }
 


### PR DESCRIPTION
Loved this library.  But when I passed "ventHoles=true" to the "enclosureLid" call, nothing changed.  I added code to create holes over the pins in the lid when you generate "enclosureLid(ventHoles=true)". This will also make it easier to connect a cased Arduino to outside sensors or actuator controls. 

I have printed an Uno lid successfully with this mod, and I examined it on a couple of different wall thicknesses and board types. You know the code better than I do though, so I may not have covered every  possibility.